### PR TITLE
Allow disabling the plugin

### DIFF
--- a/app/views/settings/_searchable_selectbox_settings.html.erb
+++ b/app/views/settings/_searchable_selectbox_settings.html.erb
@@ -1,0 +1,4 @@
+<p>
+    <%= label_tag('settings[enabled]', I18n.t(:label_enable_seachable_selectbox)) %>
+    <%= check_box_tag('settings[enabled]', 1, settings['enabled']) %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,2 @@
+en:
+  label_enable_seachable_selectbox: Enable searchable selectbox

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,2 @@
+ja:
+  label_enable_seachable_selectbox: Searchable selectboxを使用

--- a/init.rb
+++ b/init.rb
@@ -5,4 +5,6 @@ Redmine::Plugin.register :redmine_searchable_selectbox do
   name 'Redmine Searchable Selectbox'
   description "This plugin changes Redmine's selectbox searchable."
   version '0.1.0'
+
+  settings default: {'enabled' => 1}, :partial => 'settings/searchable_selectbox_settings'
 end

--- a/lib/searchable_selectbox/hook_listener.rb
+++ b/lib/searchable_selectbox/hook_listener.rb
@@ -1,6 +1,8 @@
 module SearchableSelectbox
   class HookListener < Redmine::Hook::ViewListener
     def view_layouts_base_html_head(context)
+      return '' unless Setting.plugin_redmine_searchable_selectbox['enabled']
+
       stylesheet_link_tag("select2.min", :plugin => "redmine_searchable_selectbox") +
       stylesheet_link_tag("searchable_selectbox", :plugin => "redmine_searchable_selectbox") +
       javascript_include_tag("select2.full.min.js", :plugin => "redmine_searchable_selectbox") +


### PR DESCRIPTION
The change allows admins to disable the plugin. This feature is useful for the following use cases:

* **SaaS providers**: some customers don't like select boxes enhanced by Select2. With the feature added by this pull request, customers are able to disable the plugin instead of complaining to the provider
* **Redmine or plugin developers**: I found that this plugin makes a bit difficult to debug Redmine or plugins because the plugin rewrites DOM. Developers can temporarily disable the plugin instead of uninstalling it when they want

<img width="811" alt="image" src="https://user-images.githubusercontent.com/114863/89912687-cb429980-dc2d-11ea-91bf-724b2f905c74.png">

<img width="814" alt="image" src="https://user-images.githubusercontent.com/114863/89912764-e57c7780-dc2d-11ea-8d07-e99544da9cc7.png">

